### PR TITLE
[ASQ-1255] De-deprecation of sms-fu and removal of deprecated Gem::Specification#has_rdoc

### DIFF
--- a/lib/rack/throttle/limiter.rb
+++ b/lib/rack/throttle/limiter.rb
@@ -23,7 +23,7 @@ module Rack; module Throttle
     # @option options [String]  :message    ("Rate Limit Exceeded")
     # @option options [String]  :type       ("text/plain; charset=utf-8")
     def initialize(app, options = {})
-      warn "[DEPRECATION] `rack-throttle` is deprecated.  Please use consider using `rack-attack` https://github.com/rack/rack-attack instead."
+      # warn "[DEPRECATION] `rack-throttle` is deprecated.  Please use consider using `rack-attack` https://github.com/rack/rack-attack instead."
       @app, @options = app, options
     end
 

--- a/rack-throttle.gemspec
+++ b/rack-throttle.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency     'rack',      '>= 1.0.0'
 
-  gem.post_install_message       = <<-POST
-rack-throttle is no longer under active development. Please consider
-using https://github.com/rack/rack-attack instead as it is
-more feature rich & well supported.
-  POST
+#   gem.post_install_message       = <<-POST
+# rack-throttle is no longer under active development. Please consider
+# using https://github.com/rack/rack-attack instead as it is
+# more feature rich & well supported.
+#   POST
 end

--- a/rack-throttle.gemspec
+++ b/rack-throttle.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |gem|
   gem.require_paths      = %w(lib)
   gem.extensions         = %w()
   gem.test_files         = %w()
-  gem.has_rdoc           = false
 
   gem.required_ruby_version      = '>= 1.8.2'
   gem.requirements               = []

--- a/rack-throttle.gemspec
+++ b/rack-throttle.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.files              = %w(AUTHORS README.md UNLICENSE VERSION) + Dir.glob('lib/**/*.rb')
   gem.bindir             = %q(bin)
   gem.executables        = %w()
-  gem.default_executable = gem.executables.first
   gem.require_paths      = %w(lib)
   gem.extensions         = %w()
   gem.test_files         = %w()


### PR DESCRIPTION
## Description

This branch was created off of the [de-deprecate](https://github.com/smartlogic/rack-throttle/tree/de-deprecate) branch, created by Stone Filipczack, and which was previously used in the ASQ  Gemfile - do we need to merge that branch first?

The change regarding the removal of `gem.has_rdoc  = false` was made when upgrading ASQ to Ruby 3.2 in the scope of the ticket [ASQ-987](https://app.clickup.com/t/9006094761/ASQ-987), to address a deprecation warning like this:

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4.

## Motivation and Context
[ASQ-1255](https://app.clickup.com/t/9006094761/ASQ-1255) - Upgrade SmartLogic gems used in ASQ
[ASQ-987](https://app.clickup.com/t/9006094761/ASQ-987) - Upgrade ASQ from Ruby 3.0 -> 3.2

## Notes
I didn't create a separate PR for the `de-deprecate` branch, does that make a difference?
Should we create a tag after merging this branch? If yes, what should the tag version look like?